### PR TITLE
Fix new line for the release note template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,10 +5,10 @@
 ## Release Notes
 <!-- Please provide the release notes for this change. Remember to use a clear short text to describe the changes. -->
 <!-- Use the following fields as a templete, remove the ones not used. -->
-New feature - "Feature: "
-Change or enhancement - "Updated: "
-Bug fixes - "Fixed: "
-Generic message for small changes so it only appears once in the aggregated release note - "Performance and stability improvements"
+New feature - "Feature: "  
+Change or enhancement - "Updated: "  
+Bug fixes - "Fixed: "  
+Generic message for small changes so it only appears once in the aggregated release note - "Performance and stability improvements"  
 <!-- This field is mandatory. -->
 
 


### PR DESCRIPTION
Just a HOTFIX in the MarkDown for the lines in the Release Notes to be one above the other.