### PR TITLE
Delete test plan section in pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -33,10 +33,6 @@ Performance and stability improvements
 <!-- List any changes made to the application code, including the reasoning behind the changes. -->
 
 
-## Test Plan
-<!-- Place Test Specifications (if they were done) -->
-
-
 ## Additional Notes
 <!-- Provide any additional notes or information that may be relevant to this pull request. -->
 <!-- Please include any relevant links or resources, such as related issues or documentation. -->


### PR DESCRIPTION
As @hme-jbrasch mentioned in one of the dev meetings, currently test plan section is not useful since QE has no access to github repos. If it is meant for developer testing, then the comment should be updated to reflect this.